### PR TITLE
Add embedded issuance api

### DIFF
--- a/backend/internal/http/api.go
+++ b/backend/internal/http/api.go
@@ -36,6 +36,9 @@ func (a *API) Routes() *mux.Router {
 	r.HandleFunc("/api/done", a.handleVerifyDone).Methods("GET")
 	r.HandleFunc("/api/send", a.handleSendEmail).Methods("POST")
 
+	r.HandleFunc("api/embedded/send", a.handleSendEmail).Methods("POST")
+	r.HandleFunc("api/embedded/verify", a.handleVerifyEmail).Methods("POST")
+
 	spa := spaHandler{StaticPath: "../frontend/build", IndexPath: "index.html", FileServer: http.FileServer(http.Dir("../frontend/build"))}
 
 	r.PathPrefix("/").Handler(spa)

--- a/backend/internal/http/api.go
+++ b/backend/internal/http/api.go
@@ -36,8 +36,8 @@ func (a *API) Routes() *mux.Router {
 	r.HandleFunc("/api/done", a.handleVerifyDone).Methods("GET")
 	r.HandleFunc("/api/send", a.handleSendEmail).Methods("POST")
 
-	r.HandleFunc("api/embedded/send", a.handleSendEmail).Methods("POST")
-	r.HandleFunc("api/embedded/verify", a.handleVerifyEmail).Methods("POST")
+	r.HandleFunc("/api/embedded/send", a.handleSendEmail).Methods("POST")
+	r.HandleFunc("/api/embedded/verify", a.handleVerifyEmail).Methods("POST")
 
 	spa := spaHandler{StaticPath: "../frontend/build", IndexPath: "index.html", FileServer: http.FileServer(http.Dir("../frontend/build"))}
 

--- a/backend/internal/mail/templates/email_en.html
+++ b/backend/internal/mail/templates/email_en.html
@@ -139,24 +139,6 @@
                             <strong>{{.Token}}</strong>
                         </td>
                     </tr>
-
-                    <tr>
-                        <td>
-                            <table width="100%">
-                                <tr>
-                                    <td class="alt-link">
-                                        Alternatively, you can verify your email by using the link
-                                        below:<br />
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <td style="padding: 0px 24px 0px 16px; font-size: 18px; text-align: left;">
-                                        <a href="{{.Link}}" style="color:blue underline;">{{.Link}}</a>
-                                    </td>
-                                </tr>
-                            </table>
-                        </td>
-                    </tr>
                     <tr>
                         <td class="body-text">
                             Didn&#39;t request this?<br />

--- a/backend/internal/mail/templates/email_nl.html
+++ b/backend/internal/mail/templates/email_nl.html
@@ -142,23 +142,6 @@
                             <strong>{{.Token}}</strong>
                         </td>
                     </tr>
-
-                    <tr>
-                        <td>
-                            <table width="100%">
-                                <tr>
-                                    <td class="alt-link">
-                                        Je kunt ook je e-mailadres met de onderstaande link verifiëren: <br />
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <td style="padding: 0px 24px 0px 16px; font-size: 18px; text-align: left;">
-                                        <a href="{{.Link}}" style="color:blue underline;">{{.Link}}}</a>
-                                    </td>
-                                </tr>
-                            </table>
-                        </td>
-                    </tr>
                     <tr>
                         <td class="body-text">
                             Heb jij dit niet aangevraagd?<br />


### PR DESCRIPTION
Gave them their own endpoints for if the API needs to differ from the one used on the web frontend in the future.

Updated the mail templates so it doesn't provide a direct link anymore to prevent confusion when doing embedded issuance.