### PR TITLE
Use correct address for issuance from allowed RFC5322 formatted input

### DIFF
--- a/backend/internal/http/api.go
+++ b/backend/internal/http/api.go
@@ -28,7 +28,6 @@ func NewAPI(cfg *config.Config, limiter *core.TotalRateLimiter, mailer mail.Mail
 // Routes returns app's router
 
 func (a *API) Routes() *mux.Router {
-
 	r := mux.NewRouter()
 
 	r.HandleFunc("/api/health", a.handleHealthCheck).Methods("GET")
@@ -56,7 +55,6 @@ func writeJSON(w http.ResponseWriter, code int, v any) error {
 		return err
 	}
 	return nil
-
 }
 
 func writeError(w http.ResponseWriter, code int, msg string) {
@@ -80,5 +78,4 @@ func decodeJSON(w http.ResponseWriter, r *http.Request, dst any) error {
 		return errors.New("body must contain a single JSON object")
 	}
 	return nil
-
 }

--- a/backend/internal/http/handlers.go
+++ b/backend/internal/http/handlers.go
@@ -3,11 +3,11 @@ package httpapi
 import (
 	"backend/internal/issue"
 	"backend/internal/mail"
+	"backend/internal/validators"
 	"fmt"
 	"log"
 	"net"
 	"net/http"
-	netmail "net/mail"
 	"os"
 	"path/filepath"
 	"strings"
@@ -68,7 +68,6 @@ func (a *API) handleVerifyDone(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) handleVerifyEmail(w http.ResponseWriter, r *http.Request) {
-
 	// token is passed in the body as JSON from the frontend
 	var req struct {
 		Token string `json:"token"`
@@ -113,7 +112,6 @@ func (a *API) handleVerifyEmail(w http.ResponseWriter, r *http.Request) {
 	if jserr != nil {
 		log.Printf("error: %s", jserr)
 	}
-
 }
 
 func (a *API) handleSendEmail(w http.ResponseWriter, r *http.Request) {
@@ -123,13 +121,16 @@ func (a *API) handleSendEmail(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var in input
-	if err := decodeJSON(w, r, &in); err != nil || in.Email == "" {
+	if err := decodeJSON(w, r, &in); err != nil {
 		writeError(w, http.StatusBadRequest, "email_required")
 		return
 	}
 
-	if _, err := netmail.ParseAddress(in.Email); err != nil {
-		writeError(w, http.StatusBadRequest, "error_email_format")
+	// Validate email address format
+	validator := validators.EmailValidator{}
+	valid, parsedAddress, errCode := validator.ParseAndValidateEmailAddress(in.Email)
+	if !valid {
+		writeError(w, http.StatusBadRequest, *errCode)
 		return
 	}
 
@@ -149,13 +150,14 @@ func (a *API) handleSendEmail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = a.tokenStorage.StoreToken(in.Email, tok)
+	// Make sure we use the parsed email address from the validator, to ensure that we e.g. trim any whitespace and remove any full name from the RFC-5322 format
+	err = a.tokenStorage.StoreToken(*parsedAddress, tok)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "error_storing_token")
 		return
 	}
 	baseURL := strings.TrimSuffix(a.cfg.App.BaseURL, "/")
-	verifyURL := fmt.Sprintf("%s/%s/enroll#verify:%s:%s", baseURL, in.Language, in.Email, tok)
+	verifyURL := fmt.Sprintf("%s/%s/enroll#verify:%s:%s", baseURL, in.Language, *parsedAddress, tok)
 
 	tmplStr, err := mail.RenderHTMLtemplate(mailTmpl.TemplateDir, verifyURL, tok)
 
@@ -164,6 +166,7 @@ func (a *API) handleSendEmail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// For sending the email, we can used the unparsed email address from the input, since the mailer will use the parsed email address from the validator as the "To" address. This allows us to e.g. keep the full name in the "To" field if the user provided an RFC-5322 formatted email address.
 	emData := mail.Email{From: a.cfg.Mail.From, To: in.Email,
 		Subject: mailTmpl.Subject,
 		Body:    tmplStr,
@@ -172,7 +175,7 @@ func (a *API) handleSendEmail(w http.ResponseWriter, r *http.Request) {
 	// rate limit for sending emails
 	if a.limiter != nil {
 		ip := clientIP(r)
-		allow, _ := a.limiter.Allow(ip, in.Email)
+		allow, _ := a.limiter.Allow(ip, *parsedAddress)
 		if !allow {
 			writeError(w, http.StatusTooManyRequests, "error_ratelimit")
 			return

--- a/backend/internal/mail/mailer.go
+++ b/backend/internal/mail/mailer.go
@@ -29,7 +29,6 @@ func NewSmtpMailer(mcfg *config.MailConfig) *SmtpMailer {
 }
 
 func (sm SmtpMailer) SendEmail(e Email) error {
-
 	gm := gomail.NewMessage()
 	gm.SetHeader("From", e.From)
 	gm.SetHeader("To", e.To)
@@ -41,7 +40,6 @@ func (sm SmtpMailer) SendEmail(e Email) error {
 	}
 
 	return nil
-
 }
 
 type DummyMailer struct{}

--- a/backend/internal/validators/email_validator.go
+++ b/backend/internal/validators/email_validator.go
@@ -1,0 +1,39 @@
+package validators
+
+import (
+	"net/mail"
+	"strings"
+)
+
+type EmailValidator struct{}
+
+// ParseAndValidateEmailAddress checks whether the provided input is valid.
+// It accepts RFC-5322 formatted emailaddresses (i.e. "John Doe <john.doe@example.com>"), but only in lowercase.
+// It returns a boolean indicating validity, a parsed emailaddress (if valid) or an error message key (if invalid).
+// If valid, the second return value contains the parsed address from the RFC-5322 format (e.g. "john.doe@example.com").
+// If invalid, an error message is returned in the third return value.
+func (v *EmailValidator) ParseAndValidateEmailAddress(email string) (bool, *string, *string) {
+	if email == "" {
+		err := "email_required"
+		return false, nil, &err
+	}
+
+	// We don't accept quoted emailaddresses, even if something like `"John Doe" john.doe@example.com` should be valid
+	// Neither do we accept IP-address domains like `john.doe@[192.168.1.1]`
+	if strings.Contains(email, "\"") || strings.Contains(email, "[") {
+		err := "error_email_format"
+		return false, nil, &err
+	}
+
+	if addr, err := mail.ParseAddress(email); err != nil {
+		err := "error_email_format"
+		return false, nil, &err
+	} else {
+		// We only accept lowercase emailaddresses
+		if strings.ToLower(addr.Address) != addr.Address {
+			err := "error_email_format_lowercase"
+			return false, nil, &err
+		}
+		return true, &addr.Address, nil
+	}
+}

--- a/backend/internal/validators/email_validator_test.go
+++ b/backend/internal/validators/email_validator_test.go
@@ -1,0 +1,84 @@
+package validators
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ParseAndValidateEmailAddress_Given_ValidRfc5322Address_Should_ReturnPlainEmailAddress(t *testing.T) {
+	ev := EmailValidator{}
+
+	testCases := []string{
+		"John Doe <john.doe@example.com>", // full name with angle brackets
+		"   john.doe@example.com",         // leading whitespaces
+		"\t\tjohn.doe@example.com",        // leading tabs
+		"john.doe@example.com   ",         // trailing whitespaces
+		"john.doe@example.com\t",          // trailing tabs
+	}
+
+	for _, tc := range testCases {
+		valid, parsedAddress, err := ev.ParseAndValidateEmailAddress(tc)
+
+		require.True(t, valid)
+		require.Nil(t, err)
+		require.Equal(t, "john.doe@example.com", *parsedAddress)
+	}
+}
+
+func Test_ParseAndValidateEmailAddress_Given_AddressWithTag_Should_ReturnPlainEmailAddress(t *testing.T) {
+	ev := EmailValidator{}
+
+	testCases := []string{
+		"John Doe <john.doe+tag@example.com>", // full address with plus tag
+		"john.doe+tag@example.com",            // with plus tag
+	}
+
+	for _, tc := range testCases {
+		valid, parsedAddress, err := ev.ParseAndValidateEmailAddress(tc)
+
+		require.True(t, valid)
+		require.Nil(t, err)
+		require.Equal(t, "john.doe+tag@example.com", *parsedAddress)
+	}
+}
+
+func Test_ParseAndValidateEmailAddress_Given_EmailAddressesWithQuotesOrIpDomains_Should_ReturnError(t *testing.T) {
+	ev := EmailValidator{}
+
+	testCases := []string{
+		"\"John Doe\" john.doe@example.com", // valid RFC-5322 format, but we don't accept any quotes
+		"\"john.doe\"@example.com",          // quoted
+		"\"john@doe\"@example.com",          // quoted
+		"john.doe@[192.168.1.1]",            // with IP address domain
+	}
+
+	for _, tc := range testCases {
+		valid, parsedAddress, err := ev.ParseAndValidateEmailAddress(tc)
+
+		require.False(t, valid)
+		require.Nil(t, parsedAddress)
+		require.Equal(t, "error_email_format", *err)
+	}
+}
+
+func Test_ParseAndValidateEmailAddress_Given_AddressWithUppercase_Should_ReturnError(t *testing.T) {
+	ev := EmailValidator{}
+
+	testCases := []string{
+		"John Doe <John.Doe@Example.com>", // full name with angle brackets
+		"   John.Doe@Example.com",         // leading whitespaces
+		"\t\tJohn.Doe@Example.com",        // leading tabs
+		"John.Doe@Example.com   ",         // trailing whitespaces
+		"John.Doe@Example.com\t",          // trailing tabs
+		"John.Doe+tag@Example.com",        // with plus tag
+	}
+
+	for _, tc := range testCases {
+		valid, parsedAddress, err := ev.ParseAndValidateEmailAddress(tc)
+
+		require.False(t, valid)
+		require.Nil(t, parsedAddress)
+		require.Equal(t, "error_email_format_lowercase", *err)
+	}
+}

--- a/backend/tests/jwt_creator_test.go
+++ b/backend/tests/jwt_creator_test.go
@@ -18,5 +18,4 @@ func TestCreatingJwt(t *testing.T) {
 
 	require.NoError(t, err, "Failed to create the jwt for the given email")
 	require.NotEmpty(t, jwt, "jwt should not be empty")
-
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,25 +1,69 @@
 services:
+
+  irmaserver:
+    image: ghcr.io/privacybydesign/irma:v0.19.1
+    ports:
+      - 8088:8088
+    expose:
+      - 8088
+    networks:
+      irma-net:
+        aliases:
+          - is.localhost
+    entrypoint:
+      - "irma"
+      - "server"
+      - "--no-auth=false"
+      - "--requestors={\"email_issuer\":{\"auth_method\":\"publickey\",\"key_file\": \"/config/public_key.pem\"} }"
+      - "--port=8088"
+      - "--url=http://${IP}:8088"
+      #- "--jwt-privkey-file=/config/sk.pem"
+    volumes:
+      - ./backend/internal/issue/keys/:/config/
+
   go-email-issuer:
     build:
       context: .
       dockerfile: Dockerfile
-
     container_name: go-email-issuer
     ports:
       - "8080:8080"
     volumes:
       - ./internal/issue/keys/:/internal/issue/keys/
+      - ./backend/config.json:/config/config.json
     restart: unless-stopped
-    network_mode: host
+    entrypoint: ["/app/backend/bin/server", "-config", "/config/config.json"]
+    networks:
+      irma-net:
+        aliases:
+          - email-issuer.localhost
+
   redis:
     image: "bitnami/redis:latest"
     container_name: redis
     environment:
       - REDIS_PASSWORD=password
       - REDIS_PORT_NUMBER=6379
-    volumes:
-      - redis_data:/data
-    network_mode: host
+    # volumes:
+    #   - redis_data:/bitnami/redis/data
+    networks:
+      irma-net:
+        aliases:
+            - redis.localhost
+
+  mailhog:
+    image: mailhog/mailhog
+    networks:
+      irma-net:
+        aliases:
+          - mailhog.localhost
+    ports:
+      - 1025:1025
+      - 8025:8025 # Port of the web interface
 
 volumes:
   redis_data:
+
+networks:
+  irma-net:
+    driver: bridge

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -31,6 +31,7 @@ i18n
           confirm: "Confirm",
           error_email_format:
             "You did not enter a valid email address. Please check whether the email address is correct.",
+          error_email_format_lowercase: "Email address must be in lowercase.",
           error_internal:
             "Internal error. Please contact Yivi if this happens more often.",
           error_sending_email:
@@ -84,8 +85,9 @@ i18n
             "Controleer het emailadres nogmaals ter bevestiging. Kies 'Terug' om je emailadres te corrigeren.",
           back: "Terug",
           confirm: "Bevestigen",
-          error_email_address_format:
+          error_email_format:
             "Je hebt geen geldig emailadres ingevoerd. Controleer of het ingevoerde emailadres klopt.",
+          error_email_format_lowercase: "Emailadres moet in kleine letters zijn.",
           error_internal:
             "Interne fout. Neem contact op met Yivi als dit vaker voorkomt.",
           error_sending_email:


### PR DESCRIPTION
This fix prevents invalid emailaddresses from being able to be issued.
The emailaddress input is allowed to be RFC5322 formatted (for example `John Doe <john.doe@example.com>`), but the emailaddress that will be issued to the wallet will now only be `john.doe@example.com`, while the outgoing SMTP message will contain the complete RFC5322 input. This way, the `To` address is nicely formatted in the users email client.