### PR TITLE
Make verify API email case-insensitive

### DIFF
--- a/backend/internal/http/handlers.go
+++ b/backend/internal/http/handlers.go
@@ -59,7 +59,14 @@ func (a *API) handleVerifyDone(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	remove_err := a.tokenStorage.RemoveToken(req.Email)
+	validator := validators.EmailValidator{}
+	valid, parsedAddress, errCode := validator.ParseAndValidateEmailAddress(req.Email)
+	if !valid {
+		writeError(w, http.StatusBadRequest, *errCode)
+		return
+	}
+
+	remove_err := a.tokenStorage.RemoveToken(*parsedAddress)
 	if remove_err != nil {
 		writeError(w, http.StatusInternalServerError, "error_removing_token")
 		return
@@ -78,11 +85,19 @@ func (a *API) handleVerifyEmail(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "token_or_email_required")
 		return
 	}
+	// Validate and normalize the email address
+	validator := validators.EmailValidator{}
+	valid, parsedAddress, errCode := validator.ParseAndValidateEmailAddress(req.Email)
+	if !valid {
+		writeError(w, http.StatusBadRequest, *errCode)
+		return
+	}
+
 	if a.tokenStorage == nil {
 		http.Error(w, "token generator not configured", http.StatusInternalServerError)
 		return
 	}
-	expectedToken, retrieve_err := a.tokenStorage.RetrieveToken(req.Email)
+	expectedToken, retrieve_err := a.tokenStorage.RetrieveToken(*parsedAddress)
 	if retrieve_err != nil {
 		writeError(w, http.StatusBadRequest, "error_token_invalid")
 		return
@@ -99,7 +114,7 @@ func (a *API) handleVerifyEmail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	jwt, create_err := jwtCreator.CreateJwt(req.Email)
+	jwt, create_err := jwtCreator.CreateJwt(*parsedAddress)
 	if create_err != nil {
 		writeError(w, http.StatusInternalServerError, "jwt_creation_error")
 		return

--- a/backend/tests/integration_test.go
+++ b/backend/tests/integration_test.go
@@ -138,6 +138,18 @@ func TestSendEmailHappyPath(t *testing.T) {
 	}
 
 }
+func TestSendAndVerifyWithUppercaseEmail(t *testing.T) {
+	uppercaseEmail := "Test@Email.Com"
+
+	resp := makeSendEmailRequest(t, uppercaseEmail, "en")
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Verify using the same uppercase email — should match via normalization
+	res := makeVerifyEmailRequest(t, testToken, uppercaseEmail)
+	resBody := readResponseBody(t, res)
+	require.Equalf(t, http.StatusOK, res.StatusCode, "body: %v", resBody)
+}
+
 func TestSendEmailEmptyData(t *testing.T) {
 
 	res := makeSendEmailRequest(t, "", "en")


### PR DESCRIPTION
Make verify API case insensitive just like the send API.
This makes it not an error when using the same email with an uppercase letter for sending and verifying.
