### PR TITLE
chore(deps): remove unused phone-input packages

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,12 +14,10 @@
         "i18next-browser-languagedetector": "^8.1.0",
         "js-cookie": "^3.0.5",
         "jwt-decode": "^4.0.0",
-        "libphonenumber-js": "^1.12.9",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
         "react-i18next": "^15.5.1",
         "react-icons": "^5.5.0",
-        "react-international-phone": "^4.5.0",
         "react-router-dom": "^7.15.1",
         "react-turnstile": "^1.1.4"
       },
@@ -2156,12 +2154,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/libphonenumber-js": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.2.tgz",
-      "integrity": "sha512-S3kmBrptp3yRTm83NUcHy9g1vbwiWMzI8WvY22+koBJ6zkRteLnedBL2VX0MIAGwx2yiyxX4J85pceZyQ6ffgg==",
-      "license": "MIT"
-    },
     "node_modules/lightningcss": {
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
@@ -2674,15 +2666,6 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "*"
-      }
-    },
-    "node_modules/react-international-phone": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/react-international-phone/-/react-international-phone-4.8.0.tgz",
-      "integrity": "sha512-PoyXx8t0OZNZXLupZN5UtmLb8nO6PQ6f6jQvYCAtg7VzxonuBcDs/4YA4+flqZZj5QOVqN4DLY1p39mEtJAwzw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-is": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,7 +12,6 @@
         "@privacybydesign/yivi-frontend": "^0.1.3",
         "i18next": "^26.2.0",
         "i18next-browser-languagedetector": "^8.1.0",
-        "intl-tel-input": "^25.3.1",
         "js-cookie": "^3.0.5",
         "jwt-decode": "^4.0.0",
         "libphonenumber-js": "^1.12.9",
@@ -2083,12 +2082,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/intl-tel-input": {
-      "version": "25.15.1",
-      "resolved": "https://registry.npmjs.org/intl-tel-input/-/intl-tel-input-25.15.1.tgz",
-      "integrity": "sha512-v3E/Cr3vjfcw43LxsEYRJ8kDHk96ByB5d0asU9zTYgDuLivLbYymOwcISaoZibqZVB1tndzfYWxtSrmFVumFSg==",
-      "license": "MIT"
     },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,12 +13,10 @@
     "i18next-browser-languagedetector": "^8.1.0",
     "js-cookie": "^3.0.5",
     "jwt-decode": "^4.0.0",
-    "libphonenumber-js": "^1.12.9",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "react-i18next": "^15.5.1",
     "react-icons": "^5.5.0",
-    "react-international-phone": "^4.5.0",
     "react-router-dom": "^7.15.1",
     "react-turnstile": "^1.1.4"
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,6 @@
     "@privacybydesign/yivi-frontend": "^0.1.3",
     "i18next": "^26.2.0",
     "i18next-browser-languagedetector": "^8.1.0",
-    "intl-tel-input": "^25.3.1",
     "js-cookie": "^3.0.5",
     "jwt-decode": "^4.0.0",
     "libphonenumber-js": "^1.12.9",


### PR DESCRIPTION
Closes #54. Supersedes #64.

## Why
Three phone-related packages have been declared in `frontend/package.json` since the initial scaffolding commit (`43fe241` / "Setting up the go email issuer", originally inherited from the `go-sms-issuer` fork via `7587f47`) but none of them are imported anywhere under `frontend/src/`. This repo is `idin-frontend`, an email issuer — `Index.tsx` is a plain `<input type="text">` with a regex check, and `Enroll.tsx` / `Validate.tsx` / `Done.tsx` / `Error.tsx` don't touch phones either. `grep -rn -E 'react-international-phone|libphonenumber|PhoneInput' frontend/src/` and `grep -rn -wE 'phone|tel' frontend/src/` both return zero matches.

This PR drops all three:

- `intl-tel-input` (^25.3.1) — the original target, addressed #54 / superseded #64.
- `libphonenumber-js` (^1.12.9)
- `react-international-phone` (^4.5.0)

## Changes
- Remove the three packages from `frontend/package.json`.
- Regenerate `frontend/package-lock.json` (`npm install` removed 1 + 2 packages across two commits, 0 vulnerabilities).

## Verification
- `grep -rn -E 'intl-tel-input|react-international-phone|libphonenumber|PhoneInput' frontend/src` → no matches.
- `npm install` → clean, 0 vulnerabilities.
- `npm run build` → succeeds; bundle output unchanged (same content hashes before/after).

## Test plan
- [ ] CI build-frontend (en) green
- [ ] CI build-frontend (nl) green
- [ ] CI analyze-go / test-go green
- [ ] Docker image build green